### PR TITLE
Removing deprecated MAINTAINER Dockerfile tag in favour of LABEL

### DIFF
--- a/manuscript.adoc
+++ b/manuscript.adoc
@@ -153,11 +153,7 @@ LABEL extra.identifiers.biotools="comet"
 
 LABEL about.tags="Proteomics"
 
-################## MAINTAINER ######################
-
-MAINTAINER Felipe da Veiga Leprevost <felipe@leprevost.com.br>
-
-################## INSTALLATION ######################
+LABEL maintainer="Felipe da Veiga Leprevost <felipe@leprevost.com.br>"
 
 USER biodocker
 


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated